### PR TITLE
支持 pro.x.com 页面

### DIFF
--- a/background.js
+++ b/background.js
@@ -91,7 +91,12 @@ class BackgroundService {
 
   // 检查是否为Twitter标签页
   isTwitterTab(url) {
-    return url && (url.includes('twitter.com') || url.includes('x.com'));
+    return (
+      url &&
+      (url.includes('twitter.com') ||
+        url.includes('x.com') ||
+        url.includes('pro.x.com'))
+    );
   }
 
   // Twitter标签页准备就绪

--- a/content.js
+++ b/content.js
@@ -241,18 +241,23 @@ class TwitterScraper {
   // 检查是否在正确的页面
   isOnCorrectPage() {
     const currentUrl = window.location.href;
-    return currentUrl.includes("x.com") || currentUrl.includes("twitter.com");
+    return (
+      currentUrl.includes("x.com") ||
+      currentUrl.includes("twitter.com") ||
+      currentUrl.includes("pro.x.com")
+    );
   }
 
   // 检查是否在时间线页面（而不是推文详情页）
   isOnTimelinePage() {
     const currentUrl = window.location.href;
-    // 时间线页面的URL模式：x.com/home, x.com/following 等
+    // 时间线页面的URL模式：x.com/home, x.com/following, pro.x.com/home 等
     const timelinePatterns = [
       "/home",
       "/following",
       "x.com/$",
       "twitter.com/$",
+      "pro.x.com/$",
     ];
 
     // 不应该在推文详情页（包含 /status/ 的URL）
@@ -347,11 +352,11 @@ class TwitterScraper {
     }
 
     // 检查是否在时间线页面
-    if (!this.isOnTimelinePage()) {
-      console.log("当前不在时间线页面，导航到首页...");
-      window.location.href = "https://x.com/home";
-      return;
-    }
+      if (!this.isOnTimelinePage()) {
+        console.log("当前不在时间线页面，导航到首页...");
+        window.location.href = "https://pro.x.com/home";
+        return;
+      }
 
     this.isRunning = true;
     console.log("开始抓取Twitter信息...");

--- a/manifest.json
+++ b/manifest.json
@@ -13,13 +13,15 @@
   ],
   "host_permissions": [
     "https://twitter.com/*",
-    "https://x.com/*"
+    "https://x.com/*",
+    "https://pro.x.com/*"
   ],
   "content_scripts": [
     {
       "matches": [
         "https://twitter.com/*",
-        "https://x.com/*"
+        "https://x.com/*",
+        "https://pro.x.com/*"
       ],
       "js": [
         "content.js"

--- a/popup.js
+++ b/popup.js
@@ -55,7 +55,12 @@ class PopupController {
       }
       
       // 检查是否在Twitter页面
-      if (!tab.url || (!tab.url.includes('twitter.com') && !tab.url.includes('x.com'))) {
+      if (
+        !tab.url ||
+        (!tab.url.includes('twitter.com') &&
+          !tab.url.includes('x.com') &&
+          !tab.url.includes('pro.x.com'))
+      ) {
         throw new Error('当前页面不是Twitter/X页面');
       }
       
@@ -90,16 +95,20 @@ class PopupController {
       const tab = await this.getCurrentTab();
       
       // 如果不在Twitter页面，先导航到Twitter首页
-      if (!tab.url.includes('twitter.com') && !tab.url.includes('x.com')) {
+      if (
+        !tab.url.includes('twitter.com') &&
+        !tab.url.includes('x.com') &&
+        !tab.url.includes('pro.x.com')
+      ) {
         console.log('导航到Twitter首页...');
-        await chrome.tabs.update(tab.id, { url: 'https://x.com/home' });
+        await chrome.tabs.update(tab.id, { url: 'https://pro.x.com/home' });
         
         // 等待页面加载完成
         await new Promise(resolve => setTimeout(resolve, 5000));
         
         // 重新获取标签页信息
         const updatedTab = await chrome.tabs.get(tab.id);
-        if (!updatedTab.url.includes('x.com')) {
+        if (!updatedTab.url.includes('x.com') && !updatedTab.url.includes('pro.x.com')) {
           this.showMessage('导航到Twitter失败，请手动访问Twitter', 'error');
           return;
         }


### PR DESCRIPTION
## Summary
- allow extension to operate on pro.x.com
- extend domain checks for background, popup and content scripts
- adjust default navigation URL

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6882704668fc832d87b1f56cd97ecdc7